### PR TITLE
correct preedit_format for 'biang'

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -100,7 +100,7 @@ translator:
     - xform/(\w)p/$1un/
     - xform/([jqx])s/$1iong/
     - xform/(\w)s/$1ong/
-    - xform/([jqxnl])d/$1iang/
+    - xform/([jqxnlb])d/$1iang/
     - xform/(\w)d/$1uang/
     - xform/(\w)f/$1en/
     - xform/(\w)h/$1ang/

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -91,7 +91,7 @@ translator:
     - xform/(\w)w/$1ian/
     - xform/([dtnljqx])r/$1iu/  # 對應多種韻母的雙拼碼，按搭配的聲母做區分（最好別用排除式如 [^o]r 容易出狀況）
     - xform/0r/0er/             # 另一種情況，注意先不消除0，以防後面把e當作聲母轉換爲ch
-    - xform/([nljqx])t/$1iang/
+    - xform/([nljqxb])t/$1iang/
     - xform/(\w)t/$1uang/       # 上一行已經把對應到 iang 的雙拼碼 t 消滅，於是這裏不用再列舉相配的聲母
     - xform/(\w)y/$1ing/
     - xform/([dtnlgkhaevrzcs])o/$1uo/

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -105,7 +105,7 @@ translator:
     - xform/(\w)j/$1an/
     - xform/([gkhvuirzcs])k/$1uai/
     - xform/(\w)k/$1ing/
-    - xform/([jqxnl])l/$1iang/
+    - xform/([jqxnlb])l/$1iang/
     - xform/(\w)l/$1uang/
     - xform/(\w)z/$1ou/
     - xform/([gkhvuirzcs])x/$1ua/

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -107,7 +107,7 @@ translator:
     - xform/(\w)p/$1un/
     - xform/([jqx])s/$1iong/
     - xform/(\w)s/$1ong/
-    - xform/([jqxnl])d/$1iang/
+    - xform/([jqxnlb])d/$1iang/
     - xform/(\w)d/$1uang/
     - xform/(\w)f/$1en/
     - xform/(\w)h/$1ang/

--- a/double_pinyin_pyjj.schema.yaml
+++ b/double_pinyin_pyjj.schema.yaml
@@ -104,7 +104,7 @@ translator:
     - xform/(\w)z/$1UN/
     - xform/([jqx])y/$1IONG/
     - xform/(\w)y/$1ONG/
-    - xform/([jqxnl])h/$1IANG/
+    - xform/([jqxnlb])h/$1IANG/
     - xform/(\w)h/$1UANG/
     - xform/(\w)r/$1EN/
     - xform/(\w)g/$1ANG/


### PR DESCRIPTION
朙月拼音中已有「𰻞」（U+30EDE）：

[rime-luna-pinyin](https://github.com/rime/rime-luna-pinyin/tree/master)/luna_pinyin.dict.yaml, line 49007

```
𰻞	biang
```

當前規則中未處理該音節，以小鶴雙拼爲例，鍵入「bl」顯示爲「buang」：

![Screenshot_20240312_213946](https://github.com/rime/rime-double-pinyin/assets/121725112/f053fe53-b8fe-4393-b0b2-814d0ef1bd99)
